### PR TITLE
修复 hexo 项目为网站子目录时链接错误

### DIFF
--- a/layout/_partial/menu.ejs
+++ b/layout/_partial/menu.ejs
@@ -2,7 +2,7 @@
     <ul id="menu-menu" class="menu">
         <% for (var i in theme.menu){ %>
         <li class="<%- theme.menu[i].indexOf('http') > -1 ? " " : "pview" %> menu-item menu-item-type-post_type menu-item-object-page">
-            <%- link_to(url_for(theme.menu[i].lastIndexOf('/') > 0 ? theme.menu[i] : theme.menu[i] + '/'), i, {external: true})%>
+            <%- link_to(theme.menu[i].lastIndexOf('/') > 0 ? theme.menu[i] : theme.menu[i] + '/', i, {external: true})%>
         </li>
         <%}%>
     </ul>

--- a/layout/_partial/post/item.ejs
+++ b/layout/_partial/post/item.ejs
@@ -4,7 +4,7 @@
     </a>
     <div class="else">
         <p><%- post.date.locale("zh-cn").format("MMMM DD, YYYY") %></p>
-        <h3><%- link_to(url_for(post.path), post.title || "Untitled", {class: "posttitle"}) %></h3>
+        <h3><%- link_to(post.path, post.title || "Untitled", {class: "posttitle"}) %></h3>
         <p><%- truncate(strip_html(post.content), {length: 80, omission: '...'}) %></p>
     </div>
 </div>

--- a/layout/_partial/screen.ejs
+++ b/layout/_partial/screen.ejs
@@ -20,7 +20,7 @@
     <% if ( first ) { %>
     <div id="post0">
         <p><%- first.date.locale("zh-cn").format("MMMM DD, YYYY") %></p>
-        <h2><%- link_to(url_for(first.path), first.title || config.title, {class: "posttitle"}) %></h2>
+        <h2><%- link_to(first.path, first.title || config.title, {class: "posttitle"}) %></h2>
         <p class="summary"><%- truncate(strip_html(first.content), {length: 60, omission: '...'}) %></p>
     </div>
     <% } %>


### PR DESCRIPTION
将 hexo 项目作为网站子目录时在根目录进行如下配置
```
root: /blog/
```

最终生成的静态页面的链接中包含两个 `blog` 字段，原因应该是  `url_for` 和 `link_to` 都会在路径前加上根路径。

修复方式为，避免同时使用 `url_for` 和 `link_to` 。