### PR TITLE
fix MathJax bug and toc bug

### DIFF
--- a/source/js/diaspora.js
+++ b/source/js/diaspora.js
@@ -105,6 +105,8 @@ var Diaspora = {
                     comment.click();
                 }
             }, 0)
+            var math = document.getElementById("single")
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub, math])
         })
     },
     preview: function() {
@@ -543,7 +545,7 @@ $(function() {
                 }else{
                   hash = $(e.target).attr('href')
                 }
-                to  = $("a.headerlink[href='" + hash + "']")
+                to  = $(decodeURI(hash))
                 $("html,body").animate({
                   scrollTop: to.offset().top - 50
                 }, 300);


### PR DESCRIPTION
处理两个bug：
1. 在主页进入文章情况下，第一次LaTex公式不会出现。需要MathJax在ajax加载完成后重新动态加载。
2. 由于目录查找DOM元素出现错误，导致从主页进入文章的情况下，在点击过目录之后无法一次回到主页，并且目录跳转的位置不正常。更改查找超链接元素为查找标题元素。