### PR TITLE
GA4支援

### DIFF
--- a/layout/_partial/google-analytics.ejs
+++ b/layout/_partial/google-analytics.ejs
@@ -1,13 +1,13 @@
 <% if (theme.google_analytics){ %>
 <!-- Google Analytics -->
-<script type="text/javascript">
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.google_analytics %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  ga('create', '<%= theme.google_analytics %>', 'auto');
-  ga('send', 'pageview');
+  gtag('config', '<%= theme.google_analytics %>');
 </script>
 <!-- End Google Analytics -->
 <% } %>


### PR DESCRIPTION
Google Analytics 4更新后全局（包括GA3和Universal Analytics）使用新的gtag.js，旧版页面代码貌似已无法正常配置Google Analytics，故作修正