### PR TITLE
fix some small HTML syntax problems

### DIFF
--- a/layout/_partial/post/article.ejs
+++ b/layout/_partial/post/article.ejs
@@ -15,9 +15,9 @@
                 <ul id="audio-list" style="display:none">
                     <% for (var i in theme.mp3){ %>
                         <% if (theme.mp3[i].indexOf('http') == 0){%>
-                            <li title='<%- i %>' data-url='<%- theme.mp3[i] %>'></li>
+                            <li title="<%- i %>" data-url="<%- theme.mp3[i] %>"></li>
                         <%} else {%>
-                            <li title='<%- i %>' data-url='<%- config.root + theme.mp3[i] %>'></li>
+                            <li title="<%- i %>" data-url="<%- config.root + theme.mp3[i] %>"></li>
                         <%}%>
                     <%}%>
                 </ul>
@@ -26,7 +26,7 @@
         <%- partial('gitalk', {post: page}) %>
     </div>
     <% if (theme.TOC == true){ %>
-        <div class='side'>
+        <div class="side">
 			<%- toc(page.content, {list_number: true}) %>	
         </div>
     <%}%>

--- a/layout/_partial/post/gitalk.ejs
+++ b/layout/_partial/post/gitalk.ejs
@@ -1,12 +1,12 @@
 <% if (theme.gitalk != undefined){ %>
-    <div id='gitalk-container' class="comment link"
-		data-enable='<%=theme.gitalk.enable%>'
-        data-ae='<%=theme.gitalk.autoExpand%>'
-        data-ci='<%=theme.gitalk.clientID%>'
-        data-cs='<%=theme.gitalk.clientSecret%>'
-        data-r='<%=theme.gitalk.repo%>'
-        data-o='<%=theme.gitalk.owner%>'
-        data-a='<%=theme.gitalk.admin%>'
-        data-d='<%=theme.gitalk.distractionFreeMode%>'
+    <div id="gitalk-container" class="comment link"
+		data-enable="<%=theme.gitalk.enable%>"
+        data-ae="<%=theme.gitalk.autoExpand%>"
+        data-ci="<%=theme.gitalk.clientID%>"
+        data-cs="<%=theme.gitalk.clientSecret%>"
+        data-r="<%=theme.gitalk.repo%>"
+        data-o="<%=theme.gitalk.owner%>"
+        data-a="<%=theme.gitalk.admin%>"
+        data-d="<%=theme.gitalk.distractionFreeMode%>"
     >查看评论</div>
 <%}%>

--- a/layout/_partial/screen.ejs
+++ b/layout/_partial/screen.ejs
@@ -6,7 +6,7 @@
         </div>
     </div>
     <div id="vibrant">
-        <svg viewBox="0 0 2880 1620" height="100%" preserveAspectRatio="xMaxYMax slice">
+        <svg viewbox="0 0 2880 1620" height="100%" preserveaspectratio="xMaxYMax slice">
             <polygon opacity="0.7" points="2000,1620 0,1620 0,0 600,0 "/>
         </svg>
         <div></div>


### PR DESCRIPTION
Fix some small HTML syntax problems with the aid of HTMLHint.

使用某奇怪库压缩 HTML 代码时，因为 HTML 语法错误报错了，就用 HTMLHint 跑了一遍。

另外感谢作者移植了这么漂亮的主题，贴贴！