### PR TITLE
chore: change mathjax's cdn

### DIFF
--- a/layout/_partial/mathjax.ejs
+++ b/layout/_partial/mathjax.ejs
@@ -15,6 +15,6 @@
     });
 </script>
 
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML">
 </script>
 <% } %>


### PR DESCRIPTION
MathJax CDN shutting down on April 30, 2017. [Link](https://www.mathjax.org/cdn-shutting-down/)

MathJax recommend new CDN path. [Link](https://docs.mathjax.org/en/v2.7-latest/start.html)

```
<script type="text/javascript" async
  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML">
</script>
```