### PR TITLE
Monospace webfont support

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -49,4 +49,7 @@ var description = '';
     <% if (description) { %><meta property="og:description" content="<%= description %>"/><%}%>
     <%- css(['css/diaspora.css'])%>
     <script>window.searchDbPath = "<%= url_for('/search.xml') %>";</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet">
 </head>


### PR DESCRIPTION
主题css指定的字体Source Code Pro并非所有设备自带字体，同时css内备选引用的monospace字体在桌面端会渲染成宋体，故在`<head>`内添加引用Google Font（如下代码）使网页嵌入该字体提高代码块观感。已在自己网站测试对加载速度影响不大，可以更换国内cdn提高静态资源加载速度。
```html
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet">
```